### PR TITLE
Feat: Macroify Keywords To Limit Repetition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "shark-core"
 version = "0.1.0"
 
@@ -11,8 +29,35 @@ name = "shark-lex"
 version = "0.1.0"
 dependencies = [
  "shark-core",
+ "shark-macro",
+]
+
+[[package]]
+name = "shark-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "sharkc"
 version = "0.1.0"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/sharkc",
     "crates/shark-core",
     "crates/shark-lex",
+    "crates/shark-macro",
 ]
 resolver = "2"
 

--- a/crates/shark-lex/Cargo.toml
+++ b/crates/shark-lex/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 
 [dependencies]
 shark-core = { path = "../shark-core" }
+shark-macro = { path = "../shark-macro" }

--- a/crates/shark-lex/src/macros.rs
+++ b/crates/shark-lex/src/macros.rs
@@ -53,25 +53,3 @@ macro_rules! encode_characters {
         result
     }};
 }
-
-macro_rules! make_keywords {
-    () => {};
-
-    ($($arg:ident), *) => {
-        #[derive(Debug, Clone, PartialEq)]
-        pub enum KeywordKind {
-            $($arg),*    
-        }
-        
-        impl KeywordKind {
-            pub fn create_keyword(identifier: &str) -> Option<Self> {
-                match identifier.to_ascii_lowercase().as_str() {
-                    $(
-                        hack if hack == stringify!($arg).to_ascii_lowercase() => Some(KeywordKind::$arg), // HACK!
-                    )*
-                    _ => None,
-                }
-            }
-        }
-    }
-}

--- a/crates/shark-lex/src/macros.rs
+++ b/crates/shark-lex/src/macros.rs
@@ -53,3 +53,25 @@ macro_rules! encode_characters {
         result
     }};
 }
+
+macro_rules! make_keywords {
+    () => {};
+
+    ($($arg:ident), *) => {
+        #[derive(Debug, Clone, PartialEq)]
+        pub enum KeywordKind {
+            $($arg),*    
+        }
+        
+        impl KeywordKind {
+            pub fn create_keyword(identifier: &str) -> Option<Self> {
+                match identifier.to_ascii_lowercase().as_str() {
+                    $(
+                        hack if hack == stringify!($arg).to_ascii_lowercase() => Some(KeywordKind::$arg), // HACK!
+                    )*
+                    _ => None,
+                }
+            }
+        }
+    }
+}

--- a/crates/shark-lex/src/tests.rs
+++ b/crates/shark-lex/src/tests.rs
@@ -40,6 +40,15 @@ fn test_keyword() {
 }
 
 #[test]
+fn test_keyword_again() {
+    let mut lexer = Lexer::new(None, "FUN");
+    lexer.lex();
+
+    let expected_tokens = vec![TokenKind::Identifier(String::from("FUN"))];
+    assert!(verify_tokens(&lexer.completed_tokens, &expected_tokens));
+}
+
+#[test]
 fn test_literal_str() {
     let mut lexer = Lexer::new(None, "\"Hello, World\"");
     lexer.lex();

--- a/crates/shark-lex/src/token.rs
+++ b/crates/shark-lex/src/token.rs
@@ -151,59 +151,26 @@ impl TokenKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum KeywordKind {
-    Else,
-    Enum,
-    For,
-    Fun,
-    If,
-    In,
-    Let,
-    Mut,
-    Of,
-    Ptr,
-    Pub,
-    Ref,
-    Ret,
-    Trait,
-    Type,
-    Unsafe,
-    Use,
-    When,
-    Where,
-    Yield,
-}
-
-impl KeywordKind {
-    /// Attempts to create a keyword based on the string inputted
-    pub fn create_keyword(identifier: &str) -> Option<Self> {
-        match identifier {
-            "else" => Some(Self::Else),
-            "enum" => Some(Self::Enum),
-            "for" => Some(Self::For),
-            "fun" => Some(Self::Fun),
-            "if" => Some(Self::If),
-            "in" => Some(Self::In),
-            "let" => Some(Self::Let),
-            "mut" => Some(Self::Mut),
-            "of" => Some(Self::Of),
-            "ptr" => Some(Self::Ptr),
-            "pub" => Some(Self::Pub),
-            "ref" => Some(Self::Ref),
-            "ret" => Some(Self::Ret),
-            "trait" => Some(Self::Trait),
-            "type" => Some(Self::Type),
-            "unsafe" => Some(Self::Unsafe),
-            "use" => Some(Self::Use),
-            "when" => Some(Self::When),
-            "where" => Some(Self::Where),
-            "yield" => Some(Self::Yield),
-
-            _ => None,
-        }
-    }
-}
+make_keywords!(Else,
+               Enum,
+               For,
+               Fun,
+               If,
+               In,
+               Let,
+               Mut,
+               Of,
+               Ptr,
+               Pub,
+               Ref,
+               Ret,
+               Trait,
+               Type,
+               Unsafe,
+               Use,
+               When,
+               Where,
+               Yield);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LiteralKind {

--- a/crates/shark-lex/src/token.rs
+++ b/crates/shark-lex/src/token.rs
@@ -5,6 +5,7 @@ use crate::error::{
     UnknownNumericSuffixError,
 };
 use shark_core::source::SourcePosition;
+use shark_macro::make_keywords;
 
 /// Represents a token produced during lexical analysis. [LexerToken]s give more meaning to the
 /// source code because each token resembles are certain concept in the language such as a keyword,
@@ -151,26 +152,10 @@ impl TokenKind {
     }
 }
 
-make_keywords!(Else,
-               Enum,
-               For,
-               Fun,
-               If,
-               In,
-               Let,
-               Mut,
-               Of,
-               Ptr,
-               Pub,
-               Ref,
-               Ret,
-               Trait,
-               Type,
-               Unsafe,
-               Use,
-               When,
-               Where,
-               Yield);
+make_keywords!(
+    Else, Enum, For, Fun, If, In, Let, Mut, Of, Ptr, Pub, Ref, Ret, Trait, Type, Unsafe, Use, When,
+    Where, Yield
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LiteralKind {

--- a/crates/shark-macro/Cargo.toml
+++ b/crates/shark-macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "shark-macro"
+description = "Library for proc-macros that shark uses"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"

--- a/crates/shark-macro/src/lib.rs
+++ b/crates/shark-macro/src/lib.rs
@@ -6,6 +6,11 @@ use syn::parse_macro_input;
 
 mod util;
 
+/// Programatically creates an enum with the provided keywords then creates a function mapping a
+/// stringified version of said keyword to the enum
+///
+/// For example: The input `Fun` would map to `"fun" => KeywordKind::Fun`
+/// This macro should only be used once
 #[proc_macro]
 pub fn make_keywords(input: TokenStream) -> TokenStream {
     let IdentifierArray {

--- a/crates/shark-macro/src/lib.rs
+++ b/crates/shark-macro/src/lib.rs
@@ -1,0 +1,58 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse::Parse, parse_macro_input, punctuated::Punctuated, Ident, Token};
+
+struct IdentifierArray {
+    identifiers: Punctuated<Ident, Token![,]>,
+}
+
+impl Parse for IdentifierArray {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let identifiers = Punctuated::<Ident, Token![,]>::parse_terminated(input)?;
+        Ok(IdentifierArray { identifiers })
+    }
+}
+
+#[proc_macro]
+pub fn make_keywords(input: TokenStream) -> TokenStream {
+    let IdentifierArray {
+        identifiers: keywords,
+    } = parse_macro_input!(input as IdentifierArray);
+
+    let keyword_variants = keywords.iter().map(|x| {
+        quote! {
+            #x
+        }
+    });
+    let keyword_enum = quote! {
+        #[derive(Debug, Clone, PartialEq)]
+        pub enum KeywordKind {
+            #(#keyword_variants),*
+        }
+    };
+
+    let mapping_arms = keywords.iter().map(|x| {
+        let identifier_string = x.to_string().to_lowercase();
+        quote! {
+            #identifier_string => Some(KeywordKind::#x),
+        }
+    });
+
+    let mapping_function = quote! {
+        impl KeywordKind {
+            pub fn create_keyword(identifier: &str) -> Option<Self> {
+                match identifier {
+                    #(#mapping_arms)*
+                    _ => None,
+                }
+            }
+        }
+    };
+
+    let expanded = quote! {
+        #keyword_enum
+        #mapping_function
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/shark-macro/src/lib.rs
+++ b/crates/shark-macro/src/lib.rs
@@ -1,17 +1,10 @@
+use crate::util::IdentifierArray;
+
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse::Parse, parse_macro_input, punctuated::Punctuated, Ident, Token};
+use syn::parse_macro_input;
 
-struct IdentifierArray {
-    identifiers: Punctuated<Ident, Token![,]>,
-}
-
-impl Parse for IdentifierArray {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let identifiers = Punctuated::<Ident, Token![,]>::parse_terminated(input)?;
-        Ok(IdentifierArray { identifiers })
-    }
-}
+mod util;
 
 #[proc_macro]
 pub fn make_keywords(input: TokenStream) -> TokenStream {
@@ -19,6 +12,7 @@ pub fn make_keywords(input: TokenStream) -> TokenStream {
         identifiers: keywords,
     } = parse_macro_input!(input as IdentifierArray);
 
+    // Start - Enum Creation
     let keyword_variants = keywords.iter().map(|x| {
         quote! {
             #x
@@ -30,7 +24,9 @@ pub fn make_keywords(input: TokenStream) -> TokenStream {
             #(#keyword_variants),*
         }
     };
+    // End - Enum Creation
 
+    // Start - Mapping Function
     let mapping_arms = keywords.iter().map(|x| {
         let identifier_string = x.to_string().to_lowercase();
         quote! {
@@ -48,6 +44,7 @@ pub fn make_keywords(input: TokenStream) -> TokenStream {
             }
         }
     };
+    // End - Mapping Function
 
     let expanded = quote! {
         #keyword_enum

--- a/crates/shark-macro/src/util.rs
+++ b/crates/shark-macro/src/util.rs
@@ -1,0 +1,12 @@
+use syn::{parse::Parse, punctuated::Punctuated, Ident, Token};
+
+pub struct IdentifierArray {
+    pub identifiers: Punctuated<Ident, Token![,]>,
+}
+
+impl Parse for IdentifierArray {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let identifiers = Punctuated::<Ident, Token![,]>::parse_terminated(input)?;
+        Ok(IdentifierArray { identifiers })
+    }
+}


### PR DESCRIPTION
This PR introduces the use of a macro in order to create the `KeywordKind` enum and the function for mapping a string to a keyword.  Originally, I was going to use a normal macro however, it required a hack to work which I wasn't comfortable with. In order to make the macro less hacky I decided to use a proc_macro.
